### PR TITLE
Support multiple match strategies for buffer and snippet completions

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ require('lspconfig').basics_ls.setup({
         buffer = {
             enable = true,
             minCompletionLength = 4 -- only provide completions for words longer than 4 characters
+            matchStrategy: 'exact', -- or 'fuzzy'
         },
         path = {
             enable = true,
@@ -35,6 +36,7 @@ require('lspconfig').basics_ls.setup({
         snippet = {
             enable = false,
             sources = {} -- paths to package containing snippets, see examples below
+            matchStrategy: 'exact', -- or 'fuzzy'
         },
     }
 })

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -333,8 +333,10 @@ export function createConnection(): lsp.Connection {
 
     if (!allIdentifiers) return snippetCompletions;
 
+    const matcher = createMatcher[SETTINGS.buffer.matchStrategy](typedWord);
+
     const bufCompletions = [...new Set(allIdentifiers)]
-      .filter(x => x.length > SETTINGS.buffer.minCompletionLength)
+      .filter(x => ((x.length > SETTINGS.buffer.minCompletionLength) && matcher(x)))
       .map((identifierLike) => {
         return {
           label: identifierLike,

--- a/tests/snippets.test.ts
+++ b/tests/snippets.test.ts
@@ -12,33 +12,84 @@ describe('snippets', () => {
                 body: 'value',
                 description: 'description'
             }
-        ]
+        ],
     ]);
 
-    it('return completion item from snippet name', () => {
-        const expectedCompItems = [
-            {
-                label: 'description',
-                kind: 15,
-                insertText: 'value',
-                insertTextFormat: 2
-            }
-        ];
+    describe('match strategy exact', () => {
+        it('return completion item from snippet name', () => {
+            const expectedCompItems = [
+                {
+                    label: 'description',
+                    kind: 15,
+                    insertText: 'value',
+                    insertTextFormat: 2
+                }
+            ];
 
-        expect(snippetCache.getCompletionItems('javascript', 'pref'))
-            .toEqual(expectedCompItems);
+            expect(snippetCache.getCompletionItems('javascript', 'pref', 'exact'))
+                .toEqual(expectedCompItems);
+        });
+        it('does not return completion item from snippet name with missing characters', () => {
+            expect(snippetCache.getCompletionItems('javascript', 'pex', 'exact'))
+                .toEqual([]);
+        });
+        it('return completion item from snippet prefix', () => {
+            const expectedCompItems = [
+                {
+                    label: 'description',
+                    kind: 15,
+                    insertText: 'value',
+                    insertTextFormat: 2
+                }
+            ];
+
+            expect(snippetCache.getCompletionItems('javascript', 'na', 'exact'))
+                .toEqual(expectedCompItems);
+        });
     });
-    it('return completion item from snippet prefix', () => {
-        const expectedCompItems = [
-            {
-                label: 'description',
-                kind: 15,
-                insertText: 'value',
-                insertTextFormat: 2
-            }
-        ];
+    describe('match strategy fuzzy', () => {
+        it('return completion item from snippet name like exact', () => {
+            const expectedCompItems = [
+                {
+                    label: 'description',
+                    kind: 15,
+                    insertText: 'value',
+                    insertTextFormat: 2
+                }
+            ];
 
-        expect(snippetCache.getCompletionItems('javascript', 'na'))
-            .toEqual(expectedCompItems);
+            expect(snippetCache.getCompletionItems('javascript', 'pref', 'fuzzy'))
+                .toEqual(expectedCompItems);
+        });
+        it('return completion item from snippet name with missing characters', () => {
+            const expectedCompItems = [
+                {
+                    label: 'description',
+                    kind: 15,
+                    insertText: 'value',
+                    insertTextFormat: 2
+                }
+            ];
+
+            expect(snippetCache.getCompletionItems('javascript', 'pex', 'fuzzy'))
+                .toEqual(expectedCompItems);
+        });
+        it('does not return completion item from snippet name with missing FIRST characters', () => {
+            expect(snippetCache.getCompletionItems('javascript', 'refix', 'fuzzy'))
+                .toEqual([]);
+        });
+        it('return completion item from snippet prefix', () => {
+            const expectedCompItems = [
+                {
+                    label: 'description',
+                    kind: 15,
+                    insertText: 'value',
+                    insertTextFormat: 2
+                }
+            ];
+
+            expect(snippetCache.getCompletionItems('javascript', 'na', 'fuzzy'))
+                .toEqual(expectedCompItems);
+        });
     });
 });


### PR DESCRIPTION
This pr adds support for setting two different match strategies individually for buffer and snippet completions. This does not affect path completion as it is only triggered by the `/` char and the following narrowing of completions is done by the completion engine.

The two supported match strategies is
* `exact` - snippet prefix has to start exactly from the typed word like boundary
* `fuzzy` - snippet prefix has to start from the first character of the word boundary and contain the following characters **anywhere** in the prefix